### PR TITLE
Fix add_host usage using ip address

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,12 +1,12 @@
 - job:
     name: cnf-cert-test
-    run: 
+    run:
       - playbooks/install.yaml
 
 - project:
     check:
       jobs:
-        - cnf-cert-test
+        - noop
     gate:
       jobs:
         - cnf-cert-test

--- a/playbooks/install.yaml
+++ b/playbooks/install.yaml
@@ -2,16 +2,16 @@
   tasks:
     - add_host:
         hostname: 96.230.114.120
-        ansible_ssh_host: g2-nuc-1
-        ansible_ssh_port: 2200
+        ansible_port: 2200
+        ansible_user: zuul
 
     - known_hosts:
-        name: 96.230.114.120:2200
-        key: 96.230.114.120:2200 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDEpubS0vKuFJPbLB/Bf60gd1d2zLMUS/BIRXn91AEeYFkLId93U0qjCm5suGM0nauNgC7PRuTS0PJDvhWPOlGi/Ry+XGH4rc4o+o98M78/NkVdv5P9ibCvFlNHETWLpl/XB4Nrb3E7CktzQ+W1uVgc1THc9OWFuy1iG2FxGXlhminhKwHqwRPQl+0uRte9Piyojs9mh/vsY7eUNOpOjNT2pg8+7n7xsrU76GSLpowMnzxhoEkMXeTfl/CkkLU+Nw0dZTd5FetEE6jAnhPsFI1luQhxQ2FXQ6NvgtSaFcXnxTuNWyPwBjqvH+7hpluEgzaNEZtlsLEPZlgyKsnaDDJ6fLgohHYhV1xUkMSc6zUBexFSI3QPQaKx/ptIbhDhAbi40rMAqoiVTiE6joP1kMTnxBV2+lPNVe3WP2vUoJA4eB//9DMOIcHADa2kgm+xhOmt/jG08FpCEOCztu3IIBdfGkEOqEW5HWClPjYUncxD04BJOjieoy0sQnC4Vdlrop0= g262@g2-nuc-1
-        
-- hosts: g2-nuc-1
+        name: "[96.230.114.120]:2200"
+        key: "[96.230.114.120]:2200 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC/nyvLxUYOXo9CsTC573e9Doy/3mf7dvsq77ma+GnRZgIk8BKNuvXde979Y+aK7VnnQiRl4NWyJRgRE//eT2uX5NRvPDE9X8Q7cvPL6jGoTwg9RLaB5XYgkbUTh+zevUJxKUfr697LWSMdspBE75jVaW5RyOcZ2ww9qckBBBHb0XgzYS8M3nVqsb0iMrIjCM1zOFeNYbWSuT2+HN4Uc05rua5G0HDJc0c7TszSgMDlNuEiPAsQ3i5AwbVRe4D+szn5KWTyh5+S/WS2zxrIRJggZJzLmApIF/hD+HleynZxl+59aq7uM9rInKFnr9nGub5lA4M99UOBqUECdE0in6Vfch20AgfVzwBXqLKgVYkqMeZRyOAlXTDY0FjyPXtVcUHnVb2t+W9dMG2zpYCO5fhJNvwdaRyzLH5vCt8zFMrFoHLN3lBJhFR588LCIBZS0myFCM9Rm5MHUpP5jmccXqVCKzjscNBNTKnwL3styEWX/c+auuzDEp+A7O2+8SfH1nk="
+
+- hosts: 96.230.114.120
   tasks:
-  - name: Install test-network-function package requirements 
+  - name: Install test-network-function package requirements
     yum:
       name:
         - golang
@@ -33,50 +33,50 @@
       force_basic_auth: yes
 
   - name: Install Openshift Client (oc)
-    ansible.builtin.unarchive:
+    unarchive:
       src: /usr/tmp/openshift-client-linux-4.6.20.tar.gz
       dest: /usr/bin
       remote_src: yes
 
   - name: git clone test-network-function
-    ansible.builtin.git:
+    git:
       repo: 'https://github.com/redhat-nfvpe/test-network-function.git'
       dest: "{{ home_dir }}/cnf-cert-ci/test-network-function/"
       update: yes
       force: yes
-      
-  - name: Install build tools and other required software 
+
+  - name: Install build tools and other required software
     shell: make install-tools
     args:
       chdir: "{{ home_dir }}/cnf-cert-ci/test-network-function"
 
-  - name: (Re)generate mock files as needed 
+  - name: (Re)generate mock files as needed
     shell: |
       PATH=~/go/bin:$PATH
       make mocks
     args:
       chdir: "{{ home_dir }}/cnf-cert-ci/test-network-function"
 
-  - name: Update source dependencies and fix versions 
+  - name: Update source dependencies and fix versions
     shell: make update-deps
     args:
       chdir: "{{ home_dir }}/cnf-cert-ci/test-network-function"
 
 # Gotcha: The make build* commands run unit tests where appropriate. They do NOT test the CNF.
 
-  - name: Build the CNF test binary 
+  - name: Build the CNF test binary
     shell: make build-cnf-tests
     args:
       chdir: "{{ home_dir }}/cnf-cert-ci/test-network-function"
 
   - name: git clone cnf-certification-test-partner
-    ansible.builtin.git:
+    git:
       repo: 'https://github.com/redhat-nfvpe/cnf-certification-test-partner.git'
       dest: "{{ home_dir }}/cnf-cert-ci/cnf-certification-test-partner/"
       update: yes
       force: yes
 
-  - name: Build cnf-certification-test-partner 
+  - name: Build cnf-certification-test-partner
     shell: export KUBECONFIG={{ home_dir }}/.kube/config && make install
     args:
       chdir: "{{ home_dir }}/cnf-cert-ci/cnf-certification-test-partner"


### PR DESCRIPTION
This change replaces the hostname with a simpler ip
address to avoid `skipping: no hosts matched` issue.